### PR TITLE
fix(tests): resolve test_actual_file_rendering path validation error

### DIFF
--- a/tests/test_render_shiji_html.py
+++ b/tests/test_render_shiji_html.py
@@ -10,7 +10,8 @@ import re
 from pathlib import Path
 
 # 添加父目录到路径以导入被测模块
-sys.path.insert(0, str(Path(__file__).parent.parent))
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
 
 import render_shiji_html as rsh
 
@@ -148,17 +149,18 @@ def test_complex_text():
 
 def test_actual_file_rendering():
     """测试实际文件渲染（如果存在测试文件）"""
-    test_file = Path('chapter_md/004_周本纪.tagged.md')
+    test_file = _REPO_ROOT / 'chapter_md/004_周本纪.tagged.md'
     if not test_file.exists():
         print("⊘ 跳过文件渲染测试（测试文件不存在）")
         return True
 
-    output_file = Path('/tmp/test_render_output.html')
+    output_file = _REPO_ROOT / 'docs/test_render_output.html'
+    css_file = str(_REPO_ROOT / 'docs/css/shiji-styles.css')
     try:
         result = rsh.markdown_to_html(
             str(test_file),
             str(output_file),
-            css_file='docs/css/shiji-styles.css'
+            css_file=css_file
         )
 
         if not output_file.exists():


### PR DESCRIPTION
### 修复背景
`render_shiji_html.py` 中为了防止 GitHub Pages 相对路径失效，增加了输出路径必须位于 `docs/` 目录树内的校验逻辑（L874-880）。

`tests/test_render_shiji_html.py` 的 `test_actual_file_rendering` 用例此前硬编码了 `/tmp/test_render_output.html` 作为输出目标，导致直接运行 `python3 tests/test_render_shiji_html.py` 时必定报错（5/6 通过）。

### 改动说明
1. 定义 `_REPO_ROOT` 动态定位项目根目录，确保在任意工作目录下运行测试路径解析一致；
2. 将测试输出路径调整为 `docs/test_render_output.html`，符合 `render_shiji_html` 的输出路径约束；
3. `finally` 块确保测试完成后自动清理临时测试文件。

### 验证
- 运行 `python3 tests/test_render_shiji_html.py`，6/6 测试全部通过，无测试文件残留。