### PR TITLE
fix(special): fix 404 homepage navigation link in wars.html and generator

### DIFF
--- a/docs/special/wars.html
+++ b/docs/special/wars.html
@@ -210,7 +210,7 @@
         </div>
 
         <div class="nav">
-            <a href="../../index.html">← 返回主页</a>
+            <a href="../index.html">← 返回主页</a>
             <a href="special_index.html">专项索引</a>
             <a href="#" class="pdf">📥 下载PDF（待生成）</a>
         </div>

--- a/scripts/render_wars_html.py
+++ b/scripts/render_wars_html.py
@@ -237,7 +237,7 @@ def generate_html(json_path, output_path):
         </div>
 
         <div class="nav">
-            <a href="../../index.html">← 返回主页</a>
+            <a href="../index.html">← 返回主页</a>
             <a href="special_index.html">专项索引</a>
             <a href="#" class="pdf">📥 下载PDF（待生成）</a>
         </div>


### PR DESCRIPTION
### 修复背景
`docs/special/wars.html` 位于 `docs/special/` 目录下。该页面导航栏第 213 行原先为：
```html
<a href="../../index.html">← 返回主页</a>
```
在 GitHub Pages 环境下，`../../index.html` 会跳转至仓库根目录的 `/index.html`（超出静态站点根目录 `docs/`），点击后触发 404 Not Found 错误。

同时，生成脚本 `scripts/render_wars_html.py` 第 240 行硬编码了该错误相对路径。

### 改动说明
1. 将 `docs/special/wars.html` 导航栏中的 `../../index.html` 修复为 `../index.html`，与 `docs/special/` 目录下其余全部 14 个专项索引页面保持一致；
2. 同步修复 `scripts/render_wars_html.py` 生成模板中的相对路径，避免后续重新生成时再次覆盖为错误链接。

### 验证
- 重新运行 `python3 scripts/render_wars_html.py`，页面生成正常且 diff 保持干净准确；
- 相对路径校验确认导航链接正确解析指向 `docs/index.html`。